### PR TITLE
Add customer order history endpoint

### DIFF
--- a/src/Logic/OrdersLogic.php
+++ b/src/Logic/OrdersLogic.php
@@ -483,6 +483,26 @@ class OrdersLogic
         return $orders;
     }
 
+    public function getLastOrdersByCustomer(int $idCustomer, string $origin, int $limit = 10): array
+    {
+        switch ($origin) {
+            case 'fajasmaylu':
+                return $this->emFajasMaylu->getRepository(PsOrdersFajasMaylu::class)->findLastOrdersByCustomer($idCustomer, $limit);
+            case 'mayret':
+                return $this->entityManagerInterface->getRepository(PsOrders::class)->findLastOrdersByCustomer($idCustomer, $limit);
+            case 'all':
+                $ordersMaylu = $this->emFajasMaylu->getRepository(PsOrdersFajasMaylu::class)->findLastOrdersByCustomer($idCustomer, $limit);
+                $ordersMayret = $this->entityManagerInterface->getRepository(PsOrders::class)->findLastOrdersByCustomer($idCustomer, $limit);
+                $orders = array_merge($ordersMayret, $ordersMaylu);
+                usort($orders, function ($a, $b) {
+                    return $b->getDateAdd() <=> $a->getDateAdd();
+                });
+                return array_slice($orders, 0, $limit);
+            default:
+                return $this->entityManagerInterface->getRepository(PsOrders::class)->findLastOrdersByCustomer($idCustomer, $limit);
+        }
+    }
+
     public function updatePosSessionsTotalPayments($data)
     {
         $pos_session = $this->entityManagerInterface->getRepository(LpPosSessions::class)

--- a/src/Repository/PsOrdersRepository.php
+++ b/src/Repository/PsOrdersRepository.php
@@ -49,7 +49,7 @@ class PsOrdersRepository extends ServiceEntityRepository
         return $this->em->createQueryBuilder()
             ->select('o')
             ->from(PsOrders::class, 'o')
-            ->where('o.' . PsOrderFields::ID_CUSTOMER . ' = :id_customer')
+            ->where('IDENTITY(o.customer) = :id_customer')
             ->setParameter('id_customer', $idCustomer)
             ->orderBy('o.date_add', 'DESC')
             ->setMaxResults($limit)

--- a/src/Repository/PsOrdersRepository.php
+++ b/src/Repository/PsOrdersRepository.php
@@ -43,4 +43,17 @@ class PsOrdersRepository extends ServiceEntityRepository
             ->getQuery()
             ->getOneOrNullResult();
     }
+
+    public function findLastOrdersByCustomer(int $idCustomer, int $limit = 10): array
+    {
+        return $this->em->createQueryBuilder()
+            ->select('o')
+            ->from(PsOrders::class, 'o')
+            ->where('o.' . PsOrderFields::ID_CUSTOMER . ' = :id_customer')
+            ->setParameter('id_customer', $idCustomer)
+            ->orderBy('o.date_add', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/RepositoryFajasMaylu/PsOrdersFajasMayluRepository.php
+++ b/src/RepositoryFajasMaylu/PsOrdersFajasMayluRepository.php
@@ -49,7 +49,7 @@ class PsOrdersFajasMayluRepository extends ServiceEntityRepository
         return $this->em->createQueryBuilder()
             ->select('o')
             ->from(PsOrders::class, 'o')
-            ->where('o.' . PsOrderFields::ID_CUSTOMER . ' = :id_customer')
+            ->where('IDENTITY(o.customer) = :id_customer')
             ->setParameter('id_customer', $idCustomer)
             ->orderBy('o.date_add', 'DESC')
             ->setMaxResults($limit)

--- a/src/RepositoryFajasMaylu/PsOrdersFajasMayluRepository.php
+++ b/src/RepositoryFajasMaylu/PsOrdersFajasMayluRepository.php
@@ -43,4 +43,17 @@ class PsOrdersFajasMayluRepository extends ServiceEntityRepository
             ->getQuery()
             ->getOneOrNullResult();
     }
+
+    public function findLastOrdersByCustomer(int $idCustomer, int $limit = 10): array
+    {
+        return $this->em->createQueryBuilder()
+            ->select('o')
+            ->from(PsOrders::class, 'o')
+            ->where('o.' . PsOrderFields::ID_CUSTOMER . ' = :id_customer')
+            ->setParameter('id_customer', $idCustomer)
+            ->orderBy('o.date_add', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
 }


### PR DESCRIPTION
## Summary
- add repository method to find recent orders by customer
- add logic method for querying recent orders
- implement `/get_last_orders_by_customer` endpoint

## Testing
- `php -l src/Repository/PsOrdersRepository.php`
- `php -l src/RepositoryFajasMaylu/PsOrdersFajasMayluRepository.php`
- `php -l src/Logic/OrdersLogic.php`
- `php -l src/Controller/OrdersController.php`


------
https://chatgpt.com/codex/tasks/task_e_6859826fdcec83319cd5f7a996c3bf27