### PR TITLE
Add transaction origin endpoint

### DIFF
--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -1217,3 +1217,24 @@ Elimina una línea concreta del movimiento.
   "message": "Detail deleted"
 }
 ```
+
+### `/get_transaction_origin`
+
+**Método:** `POST`
+
+Devuelve el identificador de la transacción asociada a un detalle.
+
+### Solicitud de ejemplo
+```json
+{
+  "type": "order",
+  "id_transaction_detail": 10
+}
+```
+
+### Respuesta de ejemplo
+```json
+{
+  "id_order": 5
+}
+```

--- a/src/Controller/TransactionController.php
+++ b/src/Controller/TransactionController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Doctrine\ORM\EntityManagerInterface;
+use App\Entity\PsOrderDetail;
+use App\Entity\LpWarehouseMovementDetails;
+
+class TransactionController extends AbstractController
+{
+    private EntityManagerInterface $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    #[Route('/get_transaction_origin', name: 'get_transaction_origin', methods: ['POST'])]
+    public function getTransactionOrigin(Request $request): Response
+    {
+        $data = json_decode($request->getContent(), true);
+
+        if (!isset($data['type'], $data['id_transaction_detail'])) {
+            return new JsonResponse(['error' => 'Missing parameters'], 400);
+        }
+
+        $type = $data['type'];
+        $detailId = $data['id_transaction_detail'];
+
+        switch ($type) {
+            case 'order':
+                $detail = $this->entityManager->getRepository(PsOrderDetail::class)
+                    ->find($detailId);
+                if (!$detail) {
+                    return new JsonResponse(['error' => 'Order detail not found'], 404);
+                }
+                return new JsonResponse(['id_order' => $detail->getOrder()->getIdOrder()]);
+
+            case 'movement':
+                $detail = $this->entityManager->getRepository(LpWarehouseMovementDetails::class)
+                    ->find($detailId);
+                if (!$detail) {
+                    return new JsonResponse(['error' => 'Movement detail not found'], 404);
+                }
+                return new JsonResponse(['id_warehouse_movement' => $detail->getIdWarehouseMovement()]);
+
+            default:
+                return new JsonResponse(['error' => 'Invalid type'], 400);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `TransactionController` with POST `/get_transaction_origin`
- document new endpoint in `docs/ENDPOINTS.md`

## Testing
- `php -l src/Controller/TransactionController.php`
- `composer validate --no-check-all`

------
https://chatgpt.com/codex/tasks/task_e_686d0c7ce7608331ac9cb31c709a5e64