### PR TITLE
Add endpoints for lp_stock_fixed CRUD

### DIFF
--- a/src/Controller/StockFixedController.php
+++ b/src/Controller/StockFixedController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+use App\Entity\LpStockFixed;
+
+class StockFixedController extends AbstractController
+{
+    private $entityManagerInterface;
+
+    public function __construct(EntityManagerInterface $entityManagerInterface)
+    {
+        $this->entityManagerInterface = $entityManagerInterface;
+    }
+
+    #[Route('/get_stock_fixed', name: 'get_stock_fixed')]
+    public function getStockFixed(): Response
+    {
+        $repository = $this->entityManagerInterface->getRepository(LpStockFixed::class);
+        $stocks = $repository->findAll();
+        $data = [];
+        foreach ($stocks as $stock) {
+            $data[] = [
+                'id_stock' => $stock->getIdStock(),
+                'ean13' => $stock->getEan13(),
+                'quantity_shop_1' => $stock->getQuantityShop1(),
+                'quantity_shop_2' => $stock->getQuantityShop2(),
+                'quantity_shop_3' => $stock->getQuantityShop3(),
+            ];
+        }
+        return new JsonResponse($data);
+    }
+
+    #[Route('/create_stock_fixed', name: 'create_stock_fixed', methods: ['POST'])]
+    public function createStockFixed(Request $request): Response
+    {
+        $data = json_decode($request->getContent(), true);
+        if (!isset($data['ean13'], $data['quantity_shop_1'], $data['quantity_shop_2'], $data['quantity_shop_3'])) {
+            return new JsonResponse(['error' => 'Missing parameters'], 400);
+        }
+        $stock = new LpStockFixed();
+        $stock->setEan13($data['ean13']);
+        $stock->setQuantityShop1($data['quantity_shop_1']);
+        $stock->setQuantityShop2($data['quantity_shop_2']);
+        $stock->setQuantityShop3($data['quantity_shop_3']);
+        $this->entityManagerInterface->persist($stock);
+        $this->entityManagerInterface->flush();
+        return new JsonResponse([
+            'id_stock' => $stock->getIdStock(),
+            'ean13' => $stock->getEan13(),
+            'quantity_shop_1' => $stock->getQuantityShop1(),
+            'quantity_shop_2' => $stock->getQuantityShop2(),
+            'quantity_shop_3' => $stock->getQuantityShop3(),
+        ], Response::HTTP_CREATED);
+    }
+
+    #[Route('/update_stock_fixed', name: 'update_stock_fixed', methods: ['POST'])]
+    public function updateStockFixed(Request $request): Response
+    {
+        $data = json_decode($request->getContent(), true);
+        if (!isset($data['id_stock'])) {
+            return new JsonResponse(['error' => 'Missing parameters'], 400);
+        }
+        $stock = $this->entityManagerInterface->getRepository(LpStockFixed::class)->find($data['id_stock']);
+        if (!$stock) {
+            return new JsonResponse(['error' => 'Stock not found'], 404);
+        }
+        if (isset($data['quantity_shop_1'])) {
+            $stock->setQuantityShop1($data['quantity_shop_1']);
+        }
+        if (isset($data['quantity_shop_2'])) {
+            $stock->setQuantityShop2($data['quantity_shop_2']);
+        }
+        if (isset($data['quantity_shop_3'])) {
+            $stock->setQuantityShop3($data['quantity_shop_3']);
+        }
+        $this->entityManagerInterface->persist($stock);
+        $this->entityManagerInterface->flush();
+        return new JsonResponse([
+            'id_stock' => $stock->getIdStock(),
+            'ean13' => $stock->getEan13(),
+            'quantity_shop_1' => $stock->getQuantityShop1(),
+            'quantity_shop_2' => $stock->getQuantityShop2(),
+            'quantity_shop_3' => $stock->getQuantityShop3(),
+        ]);
+    }
+
+    #[Route('/delete_stock_fixed', name: 'delete_stock_fixed', methods: ['POST'])]
+    public function deleteStockFixed(Request $request): Response
+    {
+        $data = json_decode($request->getContent(), true);
+        if (!isset($data['id_stock'])) {
+            return new JsonResponse(['error' => 'Missing parameters'], 400);
+        }
+        $stock = $this->entityManagerInterface->getRepository(LpStockFixed::class)->find($data['id_stock']);
+        if (!$stock) {
+            return new JsonResponse(['error' => 'Stock not found'], 404);
+        }
+        $this->entityManagerInterface->remove($stock);
+        $this->entityManagerInterface->flush();
+        return new JsonResponse(['message' => 'Stock deleted']);
+    }
+}

--- a/src/Entity/LpStockFixed.php
+++ b/src/Entity/LpStockFixed.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\LpStockFixedRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: LpStockFixedRepository::class)]
+class LpStockFixed
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id_stock = null;
+
+    #[ORM\Column(type: 'string', length: 13)]
+    private ?string $ean13 = null;
+
+    #[ORM\Column(type: 'integer')]
+    private ?int $quantity_shop_1 = null;
+
+    #[ORM\Column(type: 'integer')]
+    private ?int $quantity_shop_2 = null;
+
+    #[ORM\Column(type: 'integer')]
+    private ?int $quantity_shop_3 = null;
+
+    public function getIdStock(): ?int
+    {
+        return $this->id_stock;
+    }
+
+    public function setIdStock(?int $id_stock): self
+    {
+        $this->id_stock = $id_stock;
+        return $this;
+    }
+
+    public function getEan13(): ?string
+    {
+        return $this->ean13;
+    }
+
+    public function setEan13(?string $ean13): self
+    {
+        $this->ean13 = $ean13;
+        return $this;
+    }
+
+    public function getQuantityShop1(): ?int
+    {
+        return $this->quantity_shop_1;
+    }
+
+    public function setQuantityShop1(?int $quantity_shop_1): self
+    {
+        $this->quantity_shop_1 = $quantity_shop_1;
+        return $this;
+    }
+
+    public function getQuantityShop2(): ?int
+    {
+        return $this->quantity_shop_2;
+    }
+
+    public function setQuantityShop2(?int $quantity_shop_2): self
+    {
+        $this->quantity_shop_2 = $quantity_shop_2;
+        return $this;
+    }
+
+    public function getQuantityShop3(): ?int
+    {
+        return $this->quantity_shop_3;
+    }
+
+    public function setQuantityShop3(?int $quantity_shop_3): self
+    {
+        $this->quantity_shop_3 = $quantity_shop_3;
+        return $this;
+    }
+}

--- a/src/Repository/LpStockFixedRepository.php
+++ b/src/Repository/LpStockFixedRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\LpStockFixed;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class LpStockFixedRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, LpStockFixed::class);
+    }
+}


### PR DESCRIPTION
## Summary
- create `LpStockFixed` entity
- add Doctrine repository
- implement `StockFixedController` with CRUD routes

## Testing
- `composer validate --strict`
- `php -l src/Entity/LpStockFixed.php`
- `php -l src/Repository/LpStockFixedRepository.php`
- `php -l src/Controller/StockFixedController.php`

------
https://chatgpt.com/codex/tasks/task_e_6873893806b48331af84d41a936955d2