### PR TITLE
Enhance cart rule endpoint with shop restrictions

### DIFF
--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -612,7 +612,7 @@ Lista todas las sesiones de punto de venta registradas.
 
 **Método:** `GET`
 
-Devuelve la información de un vale descuento a partir de su código.
+Devuelve la información de un vale descuento a partir de su código. Ahora también incluye las restricciones de tiendas asociadas.
 
 ### Solicitud de ejemplo
 ```http
@@ -625,7 +625,10 @@ GET /get_cart_rule?code=SUMMER24
   "code": "SUMMER24",
   "reduction_amount": 5.0,
   "reduction_percent": 0,
-  "active": true
+  "active": true,
+  "restrictions": {
+    "id_shop": "1,2"
+  }
 }
 ```
 

--- a/src/Controller/CartRuleController.php
+++ b/src/Controller/CartRuleController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Entity\PsCartRule;
 use App\Logic\CartRuleLogic;
+use App\Entity\PsCartRuleShop;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Doctrine\ORM\EntityManagerInterface;
@@ -35,6 +36,19 @@ class CartRuleController
         }
 
         $cartRuleData = $this->cartRuleLogic->generateCartRuleJSON($cartRule);
+
+        $shopRestrictions = $this->entityManagerInterface
+            ->getRepository(PsCartRuleShop::class)
+            ->findBy(['id_cart_rule' => $cartRule->getIdCartRule()]);
+
+        $idShops = array_map(static function (PsCartRuleShop $crShop) {
+            return $crShop->getIdShop();
+        }, $shopRestrictions);
+
+        $cartRuleData['restrictions'] = [
+            'id_shop' => implode(',', $idShops)
+        ];
+
         return new JsonResponse($cartRuleData, JsonResponse::HTTP_OK);
     }
 

--- a/src/Entity/PsCartRuleShop.php
+++ b/src/Entity/PsCartRuleShop.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use App\Repository\PsCartRuleShopRepository;
+
+#[ORM\Entity(repositoryClass: PsCartRuleShopRepository::class)]
+#[ORM\Table(name: 'ps_cart_rule_shop')]
+class PsCartRuleShop
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id_cart_rule = null;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id_shop = null;
+
+    public function getIdCartRule(): ?int
+    {
+        return $this->id_cart_rule;
+    }
+
+    public function setIdCartRule(?int $id_cart_rule): self
+    {
+        $this->id_cart_rule = $id_cart_rule;
+        return $this;
+    }
+
+    public function getIdShop(): ?int
+    {
+        return $this->id_shop;
+    }
+
+    public function setIdShop(?int $id_shop): self
+    {
+        $this->id_shop = $id_shop;
+        return $this;
+    }
+}

--- a/src/Repository/PsCartRuleShopRepository.php
+++ b/src/Repository/PsCartRuleShopRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\PsCartRuleShop;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class PsCartRuleShopRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PsCartRuleShop::class);
+    }
+
+    public function findByIdCartRule(int $id): array
+    {
+        return $this->createQueryBuilder('c')
+            ->andWhere('c.id_cart_rule = :id')
+            ->setParameter('id', $id)
+            ->getQuery()
+            ->getResult();
+    }
+}


### PR DESCRIPTION
## Summary
- return shop restrictions from `/get_cart_rule`
- document the new `restrictions` section in docs
- add entity and repository for `ps_cart_rule_shop`

## Testing
- `php -l src/Entity/PsCartRuleShop.php`
- `php -l src/Controller/CartRuleController.php`
- `php -l src/Repository/PsCartRuleShopRepository.php`
- `composer install` *(fails: ext-sodium missing)*

------
https://chatgpt.com/codex/tasks/task_e_68768fd042d08331a6649a907b1b74f6