### PR TITLE
Add stock fixed CRUD endpoints

### DIFF
--- a/src/Controller/StockFixedController.php
+++ b/src/Controller/StockFixedController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\LpStockFixed;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class StockFixedController extends AbstractController
+{
+    private EntityManagerInterface $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    #[Route('/stock_fixed_list', name: 'stock_fixed_list')]
+    public function list(): Response
+    {
+        $records = $this->entityManager->getRepository(LpStockFixed::class)
+            ->findBy([], ['id_stock' => 'ASC']);
+        $data = [];
+        foreach ($records as $record) {
+            $data[] = [
+                'id_stock' => $record->getIdStock(),
+                'ean13' => $record->getEan13(),
+                'quantity_shop_1' => $record->getQuantityShop1(),
+                'quantity_shop_2' => $record->getQuantityShop2(),
+                'quantity_shop_3' => $record->getQuantityShop3(),
+            ];
+        }
+        return new JsonResponse($data);
+    }
+
+    #[Route('/stock_fixed_add', name: 'stock_fixed_add', methods: ['POST'])]
+    public function add(Request $request): Response
+    {
+        $data = json_decode($request->getContent(), true);
+        if (!isset($data['ean13'], $data['quantity_shop_1'], $data['quantity_shop_2'], $data['quantity_shop_3'])) {
+            return new JsonResponse(['error' => 'Missing parameters'], Response::HTTP_BAD_REQUEST);
+        }
+        $record = new LpStockFixed();
+        $record->setEan13($data['ean13']);
+        $record->setQuantityShop1($data['quantity_shop_1']);
+        $record->setQuantityShop2($data['quantity_shop_2']);
+        $record->setQuantityShop3($data['quantity_shop_3']);
+        $this->entityManager->persist($record);
+        $this->entityManager->flush();
+        return new JsonResponse(['message' => 'Record created', 'id_stock' => $record->getIdStock()]);
+    }
+
+    #[Route('/stock_fixed_update_quantity', name: 'stock_fixed_update_quantity', methods: ['POST'])]
+    public function updateQuantity(Request $request): Response
+    {
+        $data = json_decode($request->getContent(), true);
+        if (!isset($data['id_stock'])) {
+            return new JsonResponse(['error' => 'Missing id_stock'], Response::HTTP_BAD_REQUEST);
+        }
+        $record = $this->entityManager->getRepository(LpStockFixed::class)->find($data['id_stock']);
+        if (!$record) {
+            return new JsonResponse(['error' => 'Record not found'], Response::HTTP_NOT_FOUND);
+        }
+        if (isset($data['quantity_shop_1'])) {
+            $record->setQuantityShop1($data['quantity_shop_1']);
+        }
+        if (isset($data['quantity_shop_2'])) {
+            $record->setQuantityShop2($data['quantity_shop_2']);
+        }
+        if (isset($data['quantity_shop_3'])) {
+            $record->setQuantityShop3($data['quantity_shop_3']);
+        }
+        $this->entityManager->flush();
+        return new JsonResponse(['message' => 'Record updated']);
+    }
+
+    #[Route('/stock_fixed_delete', name: 'stock_fixed_delete', methods: ['POST'])]
+    public function delete(Request $request): Response
+    {
+        $data = json_decode($request->getContent(), true);
+        if (!isset($data['id_stock'])) {
+            return new JsonResponse(['error' => 'Missing id_stock'], Response::HTTP_BAD_REQUEST);
+        }
+        $record = $this->entityManager->getRepository(LpStockFixed::class)->find($data['id_stock']);
+        if (!$record) {
+            return new JsonResponse(['error' => 'Record not found'], Response::HTTP_NOT_FOUND);
+        }
+        $this->entityManager->remove($record);
+        $this->entityManager->flush();
+        return new JsonResponse(['message' => 'Record deleted']);
+    }
+}

--- a/src/Entity/LpStockFixed.php
+++ b/src/Entity/LpStockFixed.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\LpStockFixedRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: LpStockFixedRepository::class)]
+class LpStockFixed
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id_stock = null;
+
+    #[ORM\Column(type: 'string', length: 13)]
+    private ?string $ean13 = null;
+
+    #[ORM\Column(type: 'integer')]
+    private ?int $quantity_shop_1 = null;
+
+    #[ORM\Column(type: 'integer')]
+    private ?int $quantity_shop_2 = null;
+
+    #[ORM\Column(type: 'integer')]
+    private ?int $quantity_shop_3 = null;
+
+    public function getIdStock(): ?int
+    {
+        return $this->id_stock;
+    }
+
+    public function getEan13(): ?string
+    {
+        return $this->ean13;
+    }
+
+    public function setEan13(string $ean13): static
+    {
+        $this->ean13 = $ean13;
+        return $this;
+    }
+
+    public function getQuantityShop1(): ?int
+    {
+        return $this->quantity_shop_1;
+    }
+
+    public function setQuantityShop1(int $quantity_shop_1): static
+    {
+        $this->quantity_shop_1 = $quantity_shop_1;
+        return $this;
+    }
+
+    public function getQuantityShop2(): ?int
+    {
+        return $this->quantity_shop_2;
+    }
+
+    public function setQuantityShop2(int $quantity_shop_2): static
+    {
+        $this->quantity_shop_2 = $quantity_shop_2;
+        return $this;
+    }
+
+    public function getQuantityShop3(): ?int
+    {
+        return $this->quantity_shop_3;
+    }
+
+    public function setQuantityShop3(int $quantity_shop_3): static
+    {
+        $this->quantity_shop_3 = $quantity_shop_3;
+        return $this;
+    }
+}

--- a/src/Repository/LpStockFixedRepository.php
+++ b/src/Repository/LpStockFixedRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\LpStockFixed;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class LpStockFixedRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, LpStockFixed::class);
+    }
+}


### PR DESCRIPTION
## Summary
- add `LpStockFixed` entity and repository
- implement `StockFixedController` with CRUD routes for new table

## Testing
- `composer validate --no-check-all --strict`
- `find src -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_6873893806b48331af84d41a936955d2