### PR TITLE
Add CartRule name

### DIFF
--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -613,7 +613,7 @@ Lista todas las sesiones de punto de venta registradas.
 
 **Método:** `GET`
 
-Devuelve la información de un vale descuento a partir de su código. Ahora también incluye las restricciones de tiendas asociadas.
+Devuelve la información de un vale descuento a partir de su código. Ahora también incluye el nombre obtenido de `ps_cart_rule_lang` y las restricciones de tiendas asociadas.
 
 ### Solicitud de ejemplo
 ```http
@@ -624,6 +624,7 @@ GET /get_cart_rule?code=SUMMER24
 ```json
 {
   "code": "SUMMER24",
+  "name": "VERANO",
   "reduction_amount": 5.0,
   "reduction_percent": 0,
   "active": true,
@@ -637,7 +638,7 @@ GET /get_cart_rule?code=SUMMER24
 
 **Método:** `GET`
 
-Obtiene una lista de los últimos vales generados. Opcionalmente se puede filtrar por rango de fechas.
+Obtiene una lista de los últimos vales generados. Incluye el nombre desde `ps_cart_rule_lang`. Opcionalmente se puede filtrar por rango de fechas.
 
 ### Solicitud de ejemplo
 ```json
@@ -652,6 +653,7 @@ Obtiene una lista de los últimos vales generados. Opcionalmente se puede filtra
 [
   {
     "code": "SPRING24",
+    "name": "PRIMAVERA",
     "reduction_amount": 10.0,
     "active": true
   }

--- a/src/Logic/CartRuleLogic.php
+++ b/src/Logic/CartRuleLogic.php
@@ -24,7 +24,14 @@ class CartRuleLogic
 
     public function generateCartRuleJSON($cartRule)
     {
+        $cartRuleLang = $this->entityManagerInterface->getRepository(PsCartRuleLang::class)
+            ->findOneBy([
+                'id_cart_rule' => $cartRule->getIdCartRule(),
+                'id_lang' => 1,
+            ]);
+
         $cartRuleData = [
+            'name' => $cartRuleLang?->getName(),
             'date_from' => $cartRule->getDateFrom()?->format('Y-m-d H:i:s'),
             'date_to' => $cartRule->getDateTo()?->format('Y-m-d H:i:s'),
             'id_customer' => $cartRule->getIdCustomer(),


### PR DESCRIPTION
## Summary
- fetch `name` for cart rules from `ps_cart_rule_lang`
- document that `/get_cart_rule` and `/get_cart_rules` return the cart rule name

## Testing
- `composer validate --no-interaction`

------
https://chatgpt.com/codex/tasks/task_e_6879e50249e88331bda81a09351e2657