### PR TITLE
Include control stock history in stock report

### DIFF
--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -208,6 +208,8 @@ Genera etiquetas de precio para un producto o devuelve una etiqueta existente.
 
 Obtiene un informe de stock filtrado por término de búsqueda.
 
+La respuesta incluye un campo `control_stock` con todos los identificadores de seguimiento (`id_control_stock`) del producto y combinación para la tienda solicitada, concatenados y separados por `;`.
+
 ### Solicitud de ejemplo
 
 ```json
@@ -235,7 +237,8 @@ Obtiene un informe de stock filtrado por término de búsqueda.
     "ean13_combination": "1234567890123",
     "ean13_combination_0": null,
     "price": 29.28,
-    "quantity": 16
+    "quantity": 16,
+    "control_stock": "1;50;90;100"
   }
 ]
 ```

--- a/src/Logic/ProductLogic.php
+++ b/src/Logic/ProductLogic.php
@@ -31,9 +31,34 @@ class ProductLogic
                 'ean13_combination_0' => $product['ean13_combination_0'],
                 'price' => (float) number_format((float) $product['price'] * 1.21, 2, '.', ''),
                 'quantity' => $product['quantity'],
-                //'control_stock' => $this->controlStock($product['id_product'], $product['id_product_attribute'], $product['id_shop'])
+                'control_stock' => $this->controlStock(
+                    $product['id_product'],
+                    $product['id_product_attribute'],
+                    $product['id_shop']
+                )
             ];
         }
         return $productArray;
+    }
+
+    public function controlStock($idProduct, $idProductAttribute, $idShop): string
+    {
+        $controlStocks = $this->entityManagerInterface->getRepository(LpControlStock::class)->findBy([
+            'id_product' => $idProduct,
+            'id_product_attribute' => $idProductAttribute,
+            'id_shop' => $idShop,
+            'active' => true,
+            'printed' => true,
+        ]);
+
+        if (empty($controlStocks)) {
+            return '';
+        }
+
+        $ids = array_map(static function (LpControlStock $controlStock) {
+            return $controlStock->getIdControlStock();
+        }, $controlStocks);
+
+        return implode(';', $ids);
     }
 }


### PR DESCRIPTION
## Summary
- expose `control_stock` field on `/get_stock_report` endpoint
- document control stock identifiers in stock report response

## Testing
- `php -l src/Logic/ProductLogic.php`
- `php -l src/Controller/ProductController.php`
- `composer validate --no-interaction`


------
https://chatgpt.com/codex/tasks/task_e_688f000cfee8833180399b3e92880fe2