### PR TITLE
feat: include tracking codes in stock report

### DIFF
--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -206,7 +206,9 @@ Genera etiquetas de precio para un producto o devuelve una etiqueta existente.
 
 **Método:** `POST`
 
-Obtiene un informe de stock filtrado por término de búsqueda.
+Obtiene un informe de stock filtrado por término de búsqueda. Cuando un producto tiene
+seguimientos en `lp_control_stock`, se devuelve un registro por cada uno
+concatenando el identificador del seguimiento al EAN correspondiente.
 
 ### Solicitud de ejemplo
 
@@ -232,7 +234,21 @@ Obtiene un informe de stock filtrado por término de búsqueda.
     "combination_name": null,
     "reference_combination": "ZAP-001",
     "name_category": "Deporte",
-    "ean13_combination": "1234567890123",
+    "ean13_combination": "123456789012315",
+    "ean13_combination_0": null,
+    "price": 29.28,
+    "quantity": 16
+  },
+  {
+    "id_product": 10,
+    "id_product_attribute": 0,
+    "id_stock_available": 55,
+    "id_shop": 1,
+    "product_name": "Zapatilla deportiva",
+    "combination_name": null,
+    "reference_combination": "ZAP-001",
+    "name_category": "Deporte",
+    "ean13_combination": "123456789012327",
     "ean13_combination_0": null,
     "price": 29.28,
     "quantity": 16

--- a/src/Logic/ProductLogic.php
+++ b/src/Logic/ProductLogic.php
@@ -18,22 +18,47 @@ class ProductLogic
     {
         $productArray = [];
         foreach ($products as $product) {
-            $productArray[] = [
+            $controlStocks = $this->entityManagerInterface->getRepository(LpControlStock::class)->findBy([
                 'id_product' => $product['id_product'],
                 'id_product_attribute' => $product['id_product_attribute'],
-                'id_stock_available' => $product['id_stock_available'],
-                'id_shop' => $product['id_shop'],
-                'product_name' => $product['product_name'],
-                'combination_name' => $product['combination_name'],
-                'reference_combination' => $product['reference_combination'],
-                'name_category' => $product['name_category'],
-                'ean13_combination' => $product['ean13_combination'],
-                'ean13_combination_0' => $product['ean13_combination_0'],
-                'price' => (float) number_format((float) $product['price'] * 1.21, 2, '.', ''),
-                'quantity' => $product['quantity'],
-                //'control_stock' => $this->controlStock($product['id_product'], $product['id_product_attribute'], $product['id_shop'])
-            ];
+                'id_shop' => $product['id_shop']
+            ]);
+
+            if ($controlStocks) {
+                foreach ($controlStocks as $controlStock) {
+                    $productArray[] = [
+                        'id_product' => $product['id_product'],
+                        'id_product_attribute' => $product['id_product_attribute'],
+                        'id_stock_available' => $product['id_stock_available'],
+                        'id_shop' => $product['id_shop'],
+                        'product_name' => $product['product_name'],
+                        'combination_name' => $product['combination_name'],
+                        'reference_combination' => $product['reference_combination'],
+                        'name_category' => $product['name_category'],
+                        'ean13_combination' => $product['ean13_combination'] !== null ? $product['ean13_combination'] . $controlStock->getIdControlStock() : null,
+                        'ean13_combination_0' => $product['ean13_combination'] === null && $product['ean13_combination_0'] !== null ? $product['ean13_combination_0'] . $controlStock->getIdControlStock() : null,
+                        'price' => (float) number_format((float) $product['price'] * 1.21, 2, '.', ''),
+                        'quantity' => $product['quantity'],
+                    ];
+                }
+            } else {
+                $productArray[] = [
+                    'id_product' => $product['id_product'],
+                    'id_product_attribute' => $product['id_product_attribute'],
+                    'id_stock_available' => $product['id_stock_available'],
+                    'id_shop' => $product['id_shop'],
+                    'product_name' => $product['product_name'],
+                    'combination_name' => $product['combination_name'],
+                    'reference_combination' => $product['reference_combination'],
+                    'name_category' => $product['name_category'],
+                    'ean13_combination' => $product['ean13_combination'],
+                    'ean13_combination_0' => $product['ean13_combination_0'],
+                    'price' => (float) number_format((float) $product['price'] * 1.21, 2, '.', ''),
+                    'quantity' => $product['quantity'],
+                ];
+            }
         }
+
         return $productArray;
     }
 }


### PR DESCRIPTION
## Summary
- add id_control_stock lookups to stock report and append tracking id to EAN codes
- document multiple stock report rows when product has tracking entries

## Testing
- `php -l src/Logic/ProductLogic.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_688f3f2029148331a883c737fc62994b