### PR TITLE
Skip stock tracking for products 402 and 6152

### DIFF
--- a/src/Controller/ProductController.php
+++ b/src/Controller/ProductController.php
@@ -162,10 +162,11 @@ class ProductController extends AbstractController
         $response['tags'] = [];
         for ($i = 0; $i < $data['quantity_print']; $i++) {
           $lpControlStock = $this->controlStockLogic->createControlStock($data['id_product'], $data['id_product_attribute'], $data['id_shop'], $data['ean13'], true, $data['product_name']);
-          $this->controlStockLogic->createControlStockHistory($lpControlStock->getIdControlStock(),'Se añade seguimiento al reimprimir','Reimpresion',$data['id_shop']);
-
-          $response['tags'][] = $this->controlStockLogic->generateControlStockJSON($lpControlStock);
-          $this->entityManagerInterface->persist($lpControlStock);
+          if ($lpControlStock) {
+            $this->controlStockLogic->createControlStockHistory($lpControlStock->getIdControlStock(),'Se añade seguimiento al reimprimir','Reimpresion',$data['id_shop']);
+            $response['tags'][] = $this->controlStockLogic->generateControlStockJSON($lpControlStock);
+            $this->entityManagerInterface->persist($lpControlStock);
+          }
         }
       }
     }

--- a/src/Logic/StockControllLogic.php
+++ b/src/Logic/StockControllLogic.php
@@ -23,8 +23,13 @@ class StockControllLogic
         $this->logger = $logger;
     }
 
-    public function createControlStock($idProduct, $idProductAttribute, $idShop, $ean13,$printed = false, $productName): LpControlStock
+    public function createControlStock($idProduct, $idProductAttribute, $idShop, $ean13, $printed = false, $productName = ''): ?LpControlStock
     {
+        if (in_array($idProduct, [402, 6152], true)) {
+            $this->logger->log('Control stock not created for id_product ' . $idProduct);
+            return null;
+        }
+
         $controlStock = new LpControlStock();
         $controlStock->setIdProduct($idProduct);
         $controlStock->setIdProductAtributte($idProductAttribute);

--- a/src/Logic/WareHouseMovementLogic.php
+++ b/src/Logic/WareHouseMovementLogic.php
@@ -263,26 +263,27 @@ class WareHouseMovementLogic
                         
                         for ($i = 1; $i <= $recivedQuantity; $i++) {
                             $controllStock = $this->stockControllLogic->createControlStock($idProduct,$idProductAttribute,$movement->getIdShopDestiny(),$detail->getEan13(),false,$detail->getProductName());
-                            $this->stockControllLogic->createControlStockHistory($controllStock->getIdControlStock(),'Entrada de producto','Entrada',$movement->getIdShopDestiny(),$detail->getIdWarehouseMovementDetail());
-                            $this->entityManagerInterface->persist($detail);
-                            $this->logger->log('-------------------------------INICIO---------------------------------------');
-                            $this->logger->log(
-                            ' id_control_stock ' . $controllStock->getIdControlStock()
-                            . ' id_product ' . $controllStock->getIdProduct()
-                            . ' id_product_attribute ' . $controllStock->getIdProductAtributte()
-                            . ' id_shop ' . $controllStock->getIdShop()
-                            . ' ean13 ' . $controllStock->getEan13()
-                            . ' reason ' . 'Entrada de producto'
-                            . ' type ' . 'Entrada'
-                            . ' date ' . (new \DateTime('now', new \DateTimeZone('Europe/Berlin')))->format('Y-m-d H:i:s')
-                            );
-                            $this->logger->log('-------------------------------------FIN---------------------------------');
-                            $ean13ControlStockArray[] = [
-                                'ean13' => $controllStock->getEan13(),
-                                'control_stock' => $controllStock->getIdControlStock()
-                        ];
-
-                    }
+                            if ($controllStock) {
+                                $this->stockControllLogic->createControlStockHistory($controllStock->getIdControlStock(),'Entrada de producto','Entrada',$movement->getIdShopDestiny(),$detail->getIdWarehouseMovementDetail());
+                                $this->entityManagerInterface->persist($detail);
+                                $this->logger->log('-------------------------------INICIO---------------------------------------');
+                                $this->logger->log(
+                                ' id_control_stock ' . $controllStock->getIdControlStock()
+                                . ' id_product ' . $controllStock->getIdProduct()
+                                . ' id_product_attribute ' . $controllStock->getIdProductAtributte()
+                                . ' id_shop ' . $controllStock->getIdShop()
+                                . ' ean13 ' . $controllStock->getEan13()
+                                . ' reason ' . 'Entrada de producto'
+                                . ' type ' . 'Entrada'
+                                . ' date ' . (new \DateTime('now', new \DateTimeZone('Europe/Berlin')))->format('Y-m-d H:i:s')
+                                );
+                                $this->logger->log('-------------------------------------FIN---------------------------------');
+                                $ean13ControlStockArray[] = [
+                                    'ean13' => $controllStock->getEan13(),
+                                    'control_stock' => $controllStock->getIdControlStock()
+                                ];
+                            }
+                        }
                 }
                 } elseif ($movementType === 'salida') {
                     // Update stock for origin shop only


### PR DESCRIPTION
## Summary
- Avoid creating control stock for product IDs 402 and 6152
- Handle optional control stock in product and warehouse movement flows

## Testing
- `php -l src/Logic/StockControllLogic.php`
- `php -l src/Controller/ProductController.php`
- `php -l src/Logic/WareHouseMovementLogic.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894dd646dd083319449bc4dd5b543d0