### PR TITLE
feat: register campaign cart rules

### DIFF
--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -665,7 +665,7 @@ Obtiene una lista de los últimos vales generados. Incluye el nombre desde `ps_c
 
 **Método:** `POST`
 
-Crea un nuevo vale descuento.
+Crea un nuevo vale descuento. Si `is_campaign` es `true`, los vales creados se registran en la tabla `ps_lpcrm_coupon`.
 
 ### Solicitud de ejemplo
 ```json
@@ -677,7 +677,10 @@ Crea un nuevo vale descuento.
   "quantity": 1,
   "reduction_amount": 5.0,
   "reduction_percent": 0,
-  "id_customer": 1
+  "id_customer": 1,
+  "is_campaign": true,
+  "not_combinable": 1,
+  "online_only": 1
 }
 ```
 

--- a/migrations/Version20250902185745.php
+++ b/migrations/Version20250902185745.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250902185745 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create ps_lpcrm_coupon table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE ps_lpcrm_coupon (id_lpcrm_coupon INT AUTO_INCREMENT NOT NULL, id_cart_rule INT NOT NULL, not_combinable TINYINT(1) NOT NULL, online_only TINYINT(1) NOT NULL, date_add DATETIME NOT NULL, date_upd DATETIME NOT NULL, PRIMARY KEY(id_lpcrm_coupon)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE ps_lpcrm_coupon');
+    }
+}

--- a/src/Controller/CartRuleController.php
+++ b/src/Controller/CartRuleController.php
@@ -6,6 +6,7 @@ use App\Entity\PsCartRule;
 use App\Logic\CartRuleLogic;
 use App\Entity\PsCartRuleShop;
 use App\Entity\PsOrderCartRule;
+use App\Entity\PsLpcrmCoupon;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Doctrine\ORM\EntityManagerInterface;
@@ -100,6 +101,17 @@ class CartRuleController
         for ($i = 0; $i < $quantity; $i++) {
             $newCartRule = $this->cartRuleLogic->createCartRuleFromJSON($data);
             $cartRules[] = $this->cartRuleLogic->generateCartRuleJSON($newCartRule);
+
+            if (($data['is_campaign'] ?? false) === true) {
+                $coupon = new PsLpcrmCoupon();
+                $coupon->setIdCartRule($newCartRule->getIdCartRule());
+                $coupon->setNotCombinable($data['not_combinable'] ?? true);
+                $coupon->setOnlineOnly($data['online_only'] ?? true);
+                $coupon->setDateAdd(new \DateTime('now', new \DateTimeZone('Europe/Berlin')));
+                $coupon->setDateUpd(new \DateTime('now', new \DateTimeZone('Europe/Berlin')));
+                $this->entityManagerInterface->persist($coupon);
+                $this->entityManagerInterface->flush();
+            }
         }
 
         return new JsonResponse($cartRules, JsonResponse::HTTP_CREATED);

--- a/src/Entity/PsLpcrmCoupon.php
+++ b/src/Entity/PsLpcrmCoupon.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\PsLpcrmCouponRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: PsLpcrmCouponRepository::class)]
+class PsLpcrmCoupon
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id_lpcrm_coupon = null;
+
+    #[ORM\Column]
+    private int $id_cart_rule;
+
+    #[ORM\Column(type: 'boolean')]
+    private bool $not_combinable = true;
+
+    #[ORM\Column(type: 'boolean')]
+    private bool $online_only = true;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
+    private ?\DateTimeInterface $date_add = null;
+
+    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
+    private ?\DateTimeInterface $date_upd = null;
+
+    public function getIdLpcrmCoupon(): ?int
+    {
+        return $this->id_lpcrm_coupon;
+    }
+
+    public function getIdCartRule(): int
+    {
+        return $this->id_cart_rule;
+    }
+
+    public function setIdCartRule(int $id_cart_rule): self
+    {
+        $this->id_cart_rule = $id_cart_rule;
+        return $this;
+    }
+
+    public function isNotCombinable(): bool
+    {
+        return $this->not_combinable;
+    }
+
+    public function setNotCombinable(bool $not_combinable): self
+    {
+        $this->not_combinable = $not_combinable;
+        return $this;
+    }
+
+    public function isOnlineOnly(): bool
+    {
+        return $this->online_only;
+    }
+
+    public function setOnlineOnly(bool $online_only): self
+    {
+        $this->online_only = $online_only;
+        return $this;
+    }
+
+    public function getDateAdd(): ?\DateTimeInterface
+    {
+        return $this->date_add;
+    }
+
+    public function setDateAdd(\DateTimeInterface $date_add): self
+    {
+        $this->date_add = $date_add;
+        return $this;
+    }
+
+    public function getDateUpd(): ?\DateTimeInterface
+    {
+        return $this->date_upd;
+    }
+
+    public function setDateUpd(\DateTimeInterface $date_upd): self
+    {
+        $this->date_upd = $date_upd;
+        return $this;
+    }
+}

--- a/src/Logic/CartRuleLogic.php
+++ b/src/Logic/CartRuleLogic.php
@@ -69,7 +69,7 @@ class CartRuleLogic
     {
         // Crear una nueva instancia de CartRule
         $cartRule = new PsCartRule();
-        $description = $data['is_campaign'] == true ? "CP-".$data['description'] : $data['description'];
+        $description = ($data['is_campaign'] ?? false) ? 'CP-' . $data['description'] : $data['description'];
 
         // Mapear los datos del JSON a las propiedades del CartRule
         $cartRule->setDateFrom(new \DateTime($data['date_from']));

--- a/src/Repository/PsLpcrmCouponRepository.php
+++ b/src/Repository/PsLpcrmCouponRepository.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\PsLpcrmCoupon;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class PsLpcrmCouponRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PsLpcrmCoupon::class);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ps_lpcrm_coupon` entity, repository and migration
- insert campaign cart rules into `ps_lpcrm_coupon`
- document new cart rule campaign fields

## Testing
- `php -l src/Entity/PsLpcrmCoupon.php`
- `php -l src/Repository/PsLpcrmCouponRepository.php`
- `php -l src/Controller/CartRuleController.php`
- `php -l src/Logic/CartRuleLogic.php`
- `php -l migrations/Version20250902185745.php`


------
https://chatgpt.com/codex/tasks/task_e_68b73d9638a08331833c37becf488dc2