### PR TITLE
Add filter_id_customer parameter to customer filtered endpoint

### DIFF
--- a/docs/ENDPOINTS.md
+++ b/docs/ENDPOINTS.md
@@ -725,13 +725,20 @@ Activa o comprueba el estado de una licencia para una tienda determinada.
 
 **Método:** `POST`
 
-Filtra clientes por identificador o por nombre/teléfono.
+Filtra clientes por identificador (`filter_id_customer`) o por nombre/teléfono (`filter`).
 
 ### Solicitud de ejemplo
 ```json
 {
   "origin": "all",
   "filter": "Pérez"
+}
+```
+
+```json
+{
+  "origin": "all",
+  "filter_id_customer": 42
 }
 ```
 

--- a/src/Controller/CustomerController.php
+++ b/src/Controller/CustomerController.php
@@ -37,7 +37,11 @@ class CustomerController
     
         $emMayret = $this->entityManagerInterface;
     
-        if (isset($data['id_customer'])) {
+        if (isset($data['filter_id_customer'])) {
+            $customers = $emMayret
+                ->getRepository(PsCustomer::class)
+                ->findByCustomerById($data['filter_id_customer']);
+        } elseif (isset($data['id_customer'])) {
             $customers = $emMayret
                 ->getRepository(PsCustomer::class)
                 ->findByCustomerById($data['id_customer']);


### PR DESCRIPTION
## Summary
- support filtering customers by a new `filter_id_customer` request parameter in the filtered customers endpoint
- document the new parameter and provide an example payload

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e51f8d72e8833191463fed1cf174c0